### PR TITLE
Refactor respawn event handling

### DIFF
--- a/src/main/java/net/iaxsro/rpgstats/event/PlayerLifecycleEvents.java
+++ b/src/main/java/net/iaxsro/rpgstats/event/PlayerLifecycleEvents.java
@@ -41,59 +41,33 @@ public class PlayerLifecycleEvents {
      */
     @SubscribeEvent
     public static void onPlayerRespawn(final PlayerEvent.PlayerRespawnEvent event) {
-        // Es mejor asegurarse de que es un ServerPlayer y no un FakePlayer
-        if (event.getEntity() instanceof ServerPlayer player && !event.isEndConquered()) { // event.isEndConquered() evita ejecutar en respawn tras matar al dragón
-
-            // Obtener la capacidad del jugador
-            player.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).ifPresent(stats -> {
-                int currentLevel = stats.getLevel();
-                UUID currentUUID = stats.getCurrentLevelUUID();
-
-                // Calcular bonificaciones actuales
-                AttributeCalculator.CalculatedBonuses currentBonuses = AttributeCalculator.calculateBonuses(player);
-
-                // Obtener el UUID del nivel anterior (puede ser null si es nivel 0 o no se encuentra)
-                @Nullable UUID previousUUID = (currentLevel > 0) ? PersistenceService.getUUIDForLevel(player, currentLevel - 1) : null;
-
-                // ¡Llamada completa a applyAttributeModifiers!
-                AttributeCalculator.applyAttributeModifiers(player, currentBonuses, currentLevel, currentUUID, previousUUID);
-                RpgStatsMod.LOGGER.debug("Modificadores reaplicados para nivel {} (UUID: {}) tras respawn.", currentLevel, currentUUID); // Log para confirmar
-
-                // Restaurar la salud al máximo DESPUÉS de aplicar modificadores
-                player.setHealth(player.getMaxHealth());
-                RpgStatsMod.LOGGER.debug("Salud restaurada tras respawn para {}.", player.getName().getString());
-
-            }); // Fin de ifPresent
-
-        } // Fin de if ServerPlayer
-
-        Player player = event.getEntity();
-        // El evento PlayerRespawnEvent solo se dispara en el servidor
-        if (player instanceof ServerPlayer serverPlayer) {
-            LOGGER.debug("Jugador {} reapareciendo. Sincronizando PlayerStats y aplicando lógica de respawn.", serverPlayer.getName().getString());
-            // 1. Sincronizar datos al cliente
-            syncPlayerStats(serverPlayer);
-
-            // 2. Lógica adicional post-respawn (que estaba en PlayerDataClone.onPlayerRespawn)
-            // Esta lógica debería idealmente estar en una clase de servicio como LevelingManager
-            // para mantener los manejadores de eventos limpios.
-            serverPlayer.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).ifPresent(stats -> {
-                // TODO: Mover esta lógica a LevelingManager.applyPostRespawnEffects(serverPlayer, stats);
-                // Re-aplicar modificadores basados en el nivel actual (usando el UUID guardado en stats)
-                if (stats.getCurrentLevelUUID() != null) {
-                    // Asumiendo que existe algo como:
-                    // LevelingManager.reapplyAttributeModifiers(serverPlayer, stats.getCurrentLevelUUID());
-                    LOGGER.debug("Intentando reaplicar modificadores para el nivel UUID: {}", stats.getCurrentLevelUUID());
-                    // Placeholder: Aquí iría la llamada real cuando LevelingManager exista
-                } else {
-                    LOGGER.warn("No se encontró UUID de nivel en PlayerStats para {} al respawnear.", serverPlayer.getName().getString());
-                }
-                // Restaurar vida al máximo después de aplicar modificadores de vida máxima
-                // Es importante hacerlo DESPUÉS de reaplicar modificadores que afecten MaxHealth.
-                serverPlayer.setHealth(serverPlayer.getMaxHealth());
-                LOGGER.debug("Vida restaurada para {}.", serverPlayer.getName().getString());
-            });
+        if (!(event.getEntity() instanceof ServerPlayer player) || event.isEndConquered()) {
+            return; // Evita ejecutar en respawns especiales como tras matar al dragón
         }
+
+        LOGGER.debug("Jugador {} reapareciendo. Reaplicando atributos y sincronizando PlayerStats.",
+                player.getName().getString());
+
+        // Reaplicar modificadores y restaurar salud
+        player.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).ifPresent(stats -> {
+            int currentLevel = stats.getLevel();
+            UUID currentUUID = stats.getCurrentLevelUUID();
+
+            AttributeCalculator.CalculatedBonuses currentBonuses = AttributeCalculator.calculateBonuses(player);
+            @Nullable UUID previousUUID = currentLevel > 0
+                    ? PersistenceService.getUUIDForLevel(player, currentLevel - 1)
+                    : null;
+
+            AttributeCalculator.applyAttributeModifiers(player, currentBonuses, currentLevel, currentUUID, previousUUID);
+            RpgStatsMod.LOGGER.debug("Modificadores reaplicados para nivel {} (UUID: {}) tras respawn.",
+                    currentLevel, currentUUID);
+
+            player.setHealth(player.getMaxHealth());
+            RpgStatsMod.LOGGER.debug("Salud restaurada tras respawn para {}.", player.getName().getString());
+        });
+
+        // Finalmente sincronizar los datos al cliente
+        syncPlayerStats(player);
     }
 
     /**


### PR DESCRIPTION
## Summary
- simplify player respawn event handling to reapply attributes once and sync stats

## Testing
- `bash gradlew test --console=plain` *(fails: Gradle build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68ad74253a188332bb316dae75b62752