### PR TITLE
Use constant UUID for attribute modifiers

### DIFF
--- a/src/main/java/net/iaxsro/rpgstats/event/PlayerLifecycleEvents.java
+++ b/src/main/java/net/iaxsro/rpgstats/event/PlayerLifecycleEvents.java
@@ -5,15 +5,12 @@ import net.iaxsro.rpgstats.capabilities.PlayerStats;
 import net.iaxsro.rpgstats.network.ClientboundSyncPlayerStatsPacket;
 import net.iaxsro.rpgstats.network.PacketHandler;
 import net.iaxsro.rpgstats.system.AttributeCalculator;
-import net.iaxsro.rpgstats.system.PersistenceService;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import javax.annotation.Nullable;
-import java.util.UUID;
 
 // Escucha eventos en el bus de FORGE (implícito)
 @Mod.EventBusSubscriber(modid = RpgStatsMod.MOD_ID)
@@ -51,16 +48,10 @@ public class PlayerLifecycleEvents {
         // Reaplicar modificadores y restaurar salud
         player.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).ifPresent(stats -> {
             int currentLevel = stats.getLevel();
-            UUID currentUUID = stats.getCurrentLevelUUID();
 
             AttributeCalculator.CalculatedBonuses currentBonuses = AttributeCalculator.calculateBonuses(player);
-            @Nullable UUID previousUUID = currentLevel > 0
-                    ? PersistenceService.getUUIDForLevel(player, currentLevel - 1)
-                    : null;
-
-            AttributeCalculator.applyAttributeModifiers(player, currentBonuses, currentLevel, currentUUID, previousUUID);
-            RpgStatsMod.LOGGER.debug("Modificadores reaplicados para nivel {} (UUID: {}) tras respawn.",
-                    currentLevel, currentUUID);
+            AttributeCalculator.applyAttributeModifiers(player, currentBonuses);
+            RpgStatsMod.LOGGER.debug("Modificadores reaplicados para nivel {} tras respawn.", currentLevel);
 
             player.setHealth(player.getMaxHealth());
             RpgStatsMod.LOGGER.debug("Salud restaurada tras respawn para {}.", player.getName().getString());

--- a/src/main/java/net/iaxsro/rpgstats/system/AttributeCalculator.java
+++ b/src/main/java/net/iaxsro/rpgstats/system/AttributeCalculator.java
@@ -9,8 +9,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraftforge.common.ForgeConfigSpec;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.UUID;
@@ -19,6 +17,8 @@ import java.util.function.Supplier;
 public class AttributeCalculator {
 
     private static final Logger LOGGER = RpgStatsMod.LOGGER;
+    /** UUID constante usada para los modificadores aplicados por nivel. */
+    private static final UUID LEVEL_MODIFIER_UUID = UUID.fromString("289a8420-6947-48cd-bbdb-976f291b142c");
 
     // Atributos opcionales (EpicFight, Forge) - Obtenidos de forma segura
     // Es mejor obtenerlos una vez si se usan mucho, o usar Suppliers
@@ -49,66 +49,35 @@ public class AttributeCalculator {
 
     /**
      * Aplica las bonificaciones calculadas como modificadores de atributos permanentes a la entidad.
-     * También elimina los modificadores del nivel anterior si se proporciona el UUID.
      *
-     * @param entity            La entidad a la que aplicar los modificadores.
-     * @param bonuses           Las bonificaciones calculadas.
-     * @param levelNumber       El número del nivel actual (para el nombre del modificador).
-     * @param levelUUID         El UUID único para los modificadores de este nivel.
-     * @param previousLevelUUID El UUID de los modificadores del nivel anterior (puede ser null).
+     * @param entity  La entidad a la que aplicar los modificadores.
+     * @param bonuses Las bonificaciones calculadas.
      */
-    public static void applyAttributeModifiers(LivingEntity entity, CalculatedBonuses bonuses, int levelNumber, UUID levelUUID, @Nullable UUID previousLevelUUID) {
-        LOGGER.debug("Aplicando modificadores para nivel {} (UUID: {}) a {}", levelNumber, levelUUID, entity.getName().getString());
+    public static void applyAttributeModifiers(LivingEntity entity, CalculatedBonuses bonuses) {
+        LOGGER.debug("Aplicando modificadores a {}", entity.getName().getString());
 
-        // 1. Eliminar modificadores del nivel anterior
-        if (previousLevelUUID != null) {
-            LOGGER.debug("Eliminando modificadores del nivel anterior (UUID: {})", previousLevelUUID);
-            // Vanilla Attributes
-            AttributeUtil.removePermanentModifier(entity, Attributes.ATTACK_DAMAGE, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, Attributes.MOVEMENT_SPEED, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, Attributes.MAX_HEALTH, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, Attributes.ARMOR, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, Attributes.ATTACK_SPEED, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, Attributes.ARMOR_TOUGHNESS, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, Attributes.ATTACK_KNOCKBACK, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, Attributes.KNOCKBACK_RESISTANCE, previousLevelUUID);
-            // Forge Attributes
-            AttributeUtil.removePermanentModifier(entity, FORGE_SWIM_SPEED, previousLevelUUID);
-            // Epic Fight Attributes (usando Suppliers)
-            AttributeUtil.removePermanentModifier(entity, EF_IMPACT, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, EF_ARMOR_NEGATION, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, EF_STUN_ARMOR, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, EF_MAX_STAMINA, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, EF_STAMINA_REGEN, previousLevelUUID);
-            AttributeUtil.removePermanentModifier(entity, EF_WEIGHT, previousLevelUUID);
-        }
+        // Crear nuevos modificadores con UUID constante
+        String modifierName = "Level Bonus";
 
-        // 2. Crear nuevos modificadores
-        String modifierName = "Level " + levelNumber + " Bonus"; // Nombre más descriptivo
-
-        // Creamos los modificadores usando los valores de 'bonuses' y el nuevo levelUUID
-        AttributeModifier attackDamageModifier = new AttributeModifier(levelUUID, modifierName, bonuses.attackDamageAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier movementSpeedModifier = new AttributeModifier(levelUUID, modifierName, bonuses.movementSpeedMultiplier, AttributeModifier.Operation.MULTIPLY_BASE); // Cambiado a Multiplicador
-        AttributeModifier maxHealthModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalMaxHealthAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier armorModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalArmorAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier attackSpeedModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalAttackSpeedAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier armorToughnessModifier = new AttributeModifier(levelUUID, modifierName, bonuses.armorToughnessAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier attackKnockbackModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalAttackKnockbackAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier knockbackResistanceModifier = new AttributeModifier(levelUUID, modifierName, bonuses.knockbackResistanceAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier swimSpeedModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalSwimSpeedAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier attackDamageModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.attackDamageAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier movementSpeedModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.movementSpeedMultiplier, AttributeModifier.Operation.MULTIPLY_BASE);
+        AttributeModifier maxHealthModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalMaxHealthAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier armorModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalArmorAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier attackSpeedModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalAttackSpeedAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier armorToughnessModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.armorToughnessAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier attackKnockbackModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalAttackKnockbackAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier knockbackResistanceModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.knockbackResistanceAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier swimSpeedModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalSwimSpeedAddition, AttributeModifier.Operation.ADDITION);
         // Epic Fight
-        AttributeModifier impactModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalImpactAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier armorNegationModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalArmorNegationAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier stunArmorModifier = new AttributeModifier(levelUUID, modifierName, bonuses.stunArmorAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier staminaModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalStaminaAddition, AttributeModifier.Operation.ADDITION);
-        AttributeModifier staminaRegenModifier = new AttributeModifier(levelUUID, modifierName, bonuses.totalStaminaRegenAddition, AttributeModifier.Operation.ADDITION);
-        // Weight Reduction: Originalmente era MULTIPLY_TOTAL con valor negativo.
-        // MULTIPLY_TOTAL aplica: Base * (1 + Mod1) * (1 + Mod2) ...
-        // Si queremos reducir un 10% (0.1), el modificador debe ser -0.1
-        // El bonus.totalWeightReduction es positivo, así que lo negamos.
-        AttributeModifier weightReductionModifier = new AttributeModifier(levelUUID, modifierName, -bonuses.totalWeightReduction, AttributeModifier.Operation.MULTIPLY_BASE); // Cambiado a MULTIPLY_BASE para consistencia
+        AttributeModifier impactModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalImpactAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier armorNegationModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalArmorNegationAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier stunArmorModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.stunArmorAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier staminaModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalStaminaAddition, AttributeModifier.Operation.ADDITION);
+        AttributeModifier staminaRegenModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, bonuses.totalStaminaRegenAddition, AttributeModifier.Operation.ADDITION);
+        // Weight Reduction: el bonus.totalWeightReduction es positivo, por lo que se niega.
+        AttributeModifier weightReductionModifier = new AttributeModifier(LEVEL_MODIFIER_UUID, modifierName, -bonuses.totalWeightReduction, AttributeModifier.Operation.MULTIPLY_BASE);
 
-        // 3. Aplicar nuevos modificadores
+        // Aplicar nuevos modificadores
         LOGGER.debug("Aplicando nuevos modificadores...");
         // Vanilla Attributes
         AttributeUtil.addPermanentModifier(entity, Attributes.ATTACK_DAMAGE, attackDamageModifier);
@@ -129,7 +98,7 @@ public class AttributeCalculator {
         AttributeUtil.addPermanentModifier(entity, EF_STAMINA_REGEN, staminaRegenModifier);
         AttributeUtil.addPermanentModifier(entity, EF_WEIGHT, weightReductionModifier);
 
-        LOGGER.debug("Modificadores aplicados exitosamente para nivel {}.", levelNumber);
+        LOGGER.debug("Modificadores aplicados exitosamente.");
     }
 
 

--- a/src/main/java/net/iaxsro/rpgstats/system/LevelingManager.java
+++ b/src/main/java/net/iaxsro/rpgstats/system/LevelingManager.java
@@ -77,7 +77,7 @@ public class LevelingManager {
                 AttributeCalculator.CalculatedBonuses newBonuses = AttributeCalculator.calculateBonuses(player);
 
                 // 6. Aplicar Modificadores
-                AttributeCalculator.applyAttributeModifiers(player, newBonuses, newLevelNumber, newLevelUUID, previousLevelUUID);
+                AttributeCalculator.applyAttributeModifiers(player, newBonuses);
 
                 // 7. Persistir Datos del Nuevo Nivel
                 PersistenceService.saveLevelData(player, newLevelNumber, newLevelUUID, newBonuses);
@@ -112,22 +112,11 @@ public class LevelingManager {
             statsOptional.ifPresent(stats -> {
                 // --- Lógica de post-respawn aquí dentro ---
                 int currentLevel = stats.getLevel();
-                UUID currentUUID = stats.getCurrentLevelUUID();
 
-                if (currentUUID != null && currentLevel > 0) {
-                    UUID previousUUID = PersistenceService.getUUIDForLevel(player, currentLevel - 1);
-                    LOGGER.debug("Respawn: Intentando obtener UUID para nivel previo {}: {}", currentLevel - 1, previousUUID);
-
+                if (currentLevel > 0) {
                     AttributeCalculator.CalculatedBonuses currentBonuses = AttributeCalculator.calculateBonuses(player);
-                    AttributeCalculator.applyAttributeModifiers(player, currentBonuses, currentLevel, currentUUID, previousUUID);
+                    AttributeCalculator.applyAttributeModifiers(player, currentBonuses);
                     LOGGER.debug("Modificadores reaplicados post-respawn para nivel {}.", currentLevel);
-
-                } else if (currentLevel > 0) {
-                    // Caso anómalo: tiene nivel pero no UUID.
-                    LOGGER.warn("Jugador {} tiene nivel {} pero no UUID de nivel al respawnear. Reaplicación de modificadores puede ser incompleta.", player.getName().getString(), currentLevel);
-                    // Considerar si intentar aplicar sin quitar los previos:
-                    // AttributeCalculator.CalculatedBonuses currentBonuses = AttributeCalculator.calculateBonuses(player);
-                    // AttributeCalculator.applyAttributeModifiers(player, currentBonuses, currentLevel, UUID.randomUUID(), null); // Ojo con UUID random
                 }
 
                 // Restaura la salud al máximo (después de reaplicar modificadores)
@@ -227,8 +216,8 @@ public class LevelingManager {
             // 5. Recalcular Bonificaciones para el nivel objetivo
             AttributeCalculator.CalculatedBonuses targetBonuses = AttributeCalculator.calculateBonuses(player);
 
-            // 6. Aplicar Modificadores (quita los actuales, aplica los del target)
-            AttributeCalculator.applyAttributeModifiers(player, targetBonuses, targetLevel, targetLevelData.levelUUID(), stats.getCurrentLevelUUID()); // Usa el UUID *actual* como 'previous'
+            // 6. Aplicar Modificadores
+            AttributeCalculator.applyAttributeModifiers(player, targetBonuses);
 
             // 7. Actualizar la Capacidad del Jugador
             stats.setLevel(targetLevel);


### PR DESCRIPTION
## Summary
- use a single constant UUID for level-based attribute modifiers
- simplify attribute modifier application and update call sites

## Testing
- `./gradlew build` *(fails: build command terminated after prolonged execution)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7a80d6c88332b82a78b4f1bf8d33