### PR TITLE
Remove current level UUID tracking

### DIFF
--- a/src/main/java/net/iaxsro/rpgstats/capabilities/IPlayerStats.java
+++ b/src/main/java/net/iaxsro/rpgstats/capabilities/IPlayerStats.java
@@ -2,9 +2,6 @@ package net.iaxsro.rpgstats.capabilities;
 
 import net.minecraft.nbt.CompoundTag;
 
-import javax.annotation.Nullable;
-import java.util.UUID;
-
 /**
  * Interfaz que define los datos y operaciones de la capacidad PlayerStats.
  * Esta es la interfaz que otras partes del mod deberían usar para interactuar
@@ -119,10 +116,4 @@ public interface IPlayerStats {
     boolean isFirstTimeJoining();
 
     void setFirstTimeJoining(boolean value);
-
-    // --- UUID del Nivel Actual ---
-    @Nullable
-    UUID getCurrentLevelUUID();
-
-    void setCurrentLevelUUID(@Nullable UUID uuid);
 }

--- a/src/main/java/net/iaxsro/rpgstats/capabilities/PlayerStats.java
+++ b/src/main/java/net/iaxsro/rpgstats/capabilities/PlayerStats.java
@@ -4,12 +4,10 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
-import java.util.UUID;
 
 public class PlayerStats implements IPlayerStats {
 
@@ -34,7 +32,6 @@ public class PlayerStats implements IPlayerStats {
     private static final String NBT_KEY_LEVEL = "PlayerLevel";
     private static final String NBT_KEY_NICKNAME = "Nickname";
     private static final String NBT_KEY_FIRST_JOIN = "FirstTimeJoining";
-    private static final String NBT_KEY_LEVEL_UUID = "CurrentLevelUUID";
 
     // --- Data Fields ---
     private double strengthPoints = 0.0;
@@ -52,8 +49,6 @@ public class PlayerStats implements IPlayerStats {
     private int level = 0;
     private String nickname = "";
     private boolean firstTimeJoining = true;
-    @Nullable
-    private UUID currentLevelUUID = null;
 
     @Override
     public CompoundTag saveNBTData() {
@@ -83,9 +78,6 @@ public class PlayerStats implements IPlayerStats {
         nbt.putInt(NBT_KEY_LEVEL, this.level);
         nbt.putString(NBT_KEY_NICKNAME, this.nickname != null ? this.nickname : "");
         nbt.putBoolean(NBT_KEY_FIRST_JOIN, this.firstTimeJoining);
-        if (this.currentLevelUUID != null) {
-            nbt.putUUID(NBT_KEY_LEVEL_UUID, this.currentLevelUUID);
-        }
         return nbt;
     }
 
@@ -111,12 +103,6 @@ public class PlayerStats implements IPlayerStats {
         setLevel(nbt.getInt(NBT_KEY_LEVEL));
         setNickname(nbt.getString(NBT_KEY_NICKNAME));
         setFirstTimeJoining(nbt.getBoolean(NBT_KEY_FIRST_JOIN));
-
-        if (nbt.hasUUID(NBT_KEY_LEVEL_UUID)) {
-            setCurrentLevelUUID(nbt.getUUID(NBT_KEY_LEVEL_UUID));
-        } else {
-            setCurrentLevelUUID(null);
-        }
     }
 
     // --- Getters ---
@@ -251,16 +237,6 @@ public class PlayerStats implements IPlayerStats {
         this.firstTimeJoining = value;
     }
 
-    @Override
-    @Nullable
-    public UUID getCurrentLevelUUID() {
-        return currentLevelUUID;
-    }
-
-    @Override
-    public void setCurrentLevelUUID(@Nullable UUID uuid) {
-        this.currentLevelUUID = uuid;
-    }
 
     // --- Adders ---
     @Override

--- a/src/main/java/net/iaxsro/rpgstats/capabilities/util/CapabilitiesAccessor.java
+++ b/src/main/java/net/iaxsro/rpgstats/capabilities/util/CapabilitiesAccessor.java
@@ -4,7 +4,6 @@ import net.iaxsro.rpgstats.capabilities.IPlayerStats;
 import net.iaxsro.rpgstats.capabilities.PlayerStats;
 import net.minecraft.world.entity.LivingEntity;
 
-import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -70,10 +69,6 @@ public class CapabilitiesAccessor {
     public static final StatAccessor<Boolean> firstTimeJoining = new StatAccessor<>(
             entity -> entity.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).map(IPlayerStats::isFirstTimeJoining).orElse(true),
             (entity, value) -> entity.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).ifPresent(stats -> stats.setFirstTimeJoining(value))
-    );
-    public static final StatAccessor<UUID> currentLevelUUID = new StatAccessor<>(
-            entity -> entity.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).map(IPlayerStats::getCurrentLevelUUID).orElse(null),
-            (entity, value) -> entity.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).ifPresent(stats -> stats.setCurrentLevelUUID(value))
     );
 
     /**

--- a/src/main/java/net/iaxsro/rpgstats/event/PlayerLifecycleEvents.java
+++ b/src/main/java/net/iaxsro/rpgstats/event/PlayerLifecycleEvents.java
@@ -51,7 +51,7 @@ public class PlayerLifecycleEvents {
         // Reaplicar modificadores y restaurar salud
         player.getCapability(PlayerStats.PLAYER_STATS_CAPABILITY).ifPresent(stats -> {
             int currentLevel = stats.getLevel();
-            UUID currentUUID = stats.getCurrentLevelUUID();
+            UUID currentUUID = PersistenceService.getUUIDForLevel(player, currentLevel);
 
             AttributeCalculator.CalculatedBonuses currentBonuses = AttributeCalculator.calculateBonuses(player);
             @Nullable UUID previousUUID = currentLevel > 0

--- a/src/main/java/net/iaxsro/rpgstats/system/LevelingManager.java
+++ b/src/main/java/net/iaxsro/rpgstats/system/LevelingManager.java
@@ -37,7 +37,7 @@ public class LevelingManager {
             statsOptional.ifPresent(stats -> {
                 // --- Toda la lógica de level up va aquí dentro ---
                 int currentLevel = stats.getLevel(); // Ahora es int
-                UUID previousLevelUUID = stats.getCurrentLevelUUID();
+                UUID previousLevelUUID = PersistenceService.getUUIDForLevel(player, currentLevel);
                 UUID newLevelUUID = UUID.randomUUID();
                 int newLevelNumber = currentLevel + 1;
 
@@ -69,9 +69,8 @@ public class LevelingManager {
                 stats.setConstitutionIterations(0);
                 stats.setIntelligenceIterations(0);
 
-                // 4. Actualizar Nivel y UUID en la Capacidad
+                // 4. Actualizar Nivel en la Capacidad
                 stats.setLevel(newLevelNumber);
-                stats.setCurrentLevelUUID(newLevelUUID);
 
                 // 5. Recalcular Bonificaciones
                 AttributeCalculator.CalculatedBonuses newBonuses = AttributeCalculator.calculateBonuses(player);
@@ -112,7 +111,7 @@ public class LevelingManager {
             statsOptional.ifPresent(stats -> {
                 // --- Lógica de post-respawn aquí dentro ---
                 int currentLevel = stats.getLevel();
-                UUID currentUUID = stats.getCurrentLevelUUID();
+                UUID currentUUID = PersistenceService.getUUIDForLevel(player, currentLevel);
 
                 if (currentUUID != null && currentLevel > 0) {
                     UUID previousUUID = PersistenceService.getUUIDForLevel(player, currentLevel - 1);
@@ -228,11 +227,11 @@ public class LevelingManager {
             AttributeCalculator.CalculatedBonuses targetBonuses = AttributeCalculator.calculateBonuses(player);
 
             // 6. Aplicar Modificadores (quita los actuales, aplica los del target)
-            AttributeCalculator.applyAttributeModifiers(player, targetBonuses, targetLevel, targetLevelData.levelUUID(), stats.getCurrentLevelUUID()); // Usa el UUID *actual* como 'previous'
+            UUID currentLevelUUID = PersistenceService.getUUIDForLevel(player, stats.getLevel());
+            AttributeCalculator.applyAttributeModifiers(player, targetBonuses, targetLevel, targetLevelData.levelUUID(), currentLevelUUID); // Usa el UUID *actual* como 'previous'
 
             // 7. Actualizar la Capacidad del Jugador
             stats.setLevel(targetLevel);
-            stats.setCurrentLevelUUID(targetLevelData.levelUUID());
             // Resetear puntos temporales
             stats.setStrengthPoints(0);
             stats.setDexterityPoints(0);


### PR DESCRIPTION
## Summary
- drop `currentLevelUUID` field and accessors from player stats capability
- stop serializing level UUID in NBT
- use PersistenceService to look up level UUIDs during level changes and respawn

## Testing
- `bash ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ad7a8232888332b57242f35078db19